### PR TITLE
Revert "implement Rotate={0,1,2,3} in the GLES codepath"

### DIFF
--- a/src/Config.cpp
+++ b/src/Config.cpp
@@ -338,8 +338,6 @@ BOOL InitConfiguration(void)
     ConfigSetDefaultInt(l_ConfigVideoGeneral, "ScreenHeight", 480, "Height of output window or fullscreen height");
     ConfigSetDefaultBool(l_ConfigVideoGeneral, "VerticalSync", 0, "If true, activate the SDL_GL_SWAP_CONTROL attribute");
 
-    ConfigSetDefaultInt(l_ConfigVideoGeneral, "Rotate", 0, "Rotate screen contents: 0=0 degree, 1=90 degree, 2 = 180 degree, 3=270 degree");
-
     ConfigSetDefaultInt(l_ConfigVideoRice, "Version", CONFIG_PARAM_VERSION, "Mupen64Plus Rice Video Plugin config parameter version number");
     ConfigSetDefaultInt(l_ConfigVideoRice, "FrameBufferSetting", FRM_BUF_NONE, "Frame Buffer Emulation (0=ROM default, 1=disable)");
     ConfigSetDefaultInt(l_ConfigVideoRice, "FrameBufferWriteBackControl", FRM_BUF_WRITEBACK_NORMAL, "Frequency to write back the frame buffer (0=every frame, 1=every other frame, etc)");
@@ -502,8 +500,6 @@ static void ReadConfiguration(void)
     options.bForcePolygonOffset = ConfigGetParamBool(l_ConfigVideoRice, "ForcePolygonOffset");
     options.polygonOffsetFactor = ConfigGetParamFloat(l_ConfigVideoRice, "PolygonOffsetFactor");
     options.polygonOffsetUnits = ConfigGetParamFloat(l_ConfigVideoRice, "PolygonOffsetUnits");
-
-    options.rotate = ConfigGetParamInt(l_ConfigVideoGeneral, "Rotate");
 
     CDeviceBuilder::SelectDeviceType((SupportedDeviceType)options.OpenglRenderSetting);
 

--- a/src/Config.h
+++ b/src/Config.h
@@ -216,8 +216,6 @@ typedef struct {
     float   polygonOffsetFactor;
     float   polygonOffsetUnits;
 
-    int rotate;
-
     HACK_FOR_GAMES  enableHackForGames;
 } GlobalOptions;
 

--- a/src/OGLES2FragmentShaders.cpp
+++ b/src/OGLES2FragmentShaders.cpp
@@ -40,11 +40,10 @@ const char *vertexShader =
 "varying mediump vec2 vTexCoord0;                           \n"\
 "varying lowp vec2    vTexCoord1;                           \n"\
 "varying lowp float   vFog;                                 \n"\
-"uniform mat4 rotation_matrix;                              \n"\
 "                                                           \n"\
 "void main()                                                \n"\
 "{                                                          \n"\
-"gl_Position = rotation_matrix * aPosition;                 \n"\
+"gl_Position = aPosition;                                   \n"\
 "vShadeColor = aColor;                                      \n"\
 "vTexCoord0 = aTexCoord0;                                   \n"\
 "vTexCoord1 = aTexCoord1;                                   \n"\
@@ -128,70 +127,6 @@ const char *fragmentFill =
 "}";
 
 GLuint fillProgram,fillColorLocation;
-
-void set_rotation_matrix(GLuint loc, int rotate)
-{
-    GLfloat mat[16];
-
-    /* first setup everything which is the same everytime */
-    /* (X, X, 0, 0)
-     * (X, X, 0, 0)
-     * (0, 0, 1, 0)
-     * (0, 0, 0, 1)
-     */
-
-    //mat[0] =  cos(angle);
-    //mat[1] =  sin(angle);
-    mat[2] = 0;
-    mat[3] = 0;
-
-    //mat[4] = -sin(angle);
-    //mat[5] =  cos(angle);
-    mat[6] = 0;
-    mat[7] = 0;
-
-    mat[8] = 0;
-    mat[9] = 0;
-    mat[10] = 1;
-    mat[11] = 0;
-
-    mat[12] = 0;
-    mat[13] = 0;
-    mat[14] = 0;
-    mat[15] = 1;
-
-    /* now set the actual rotation */
-    if(1 == rotate) // 90 degree
-    {
-        mat[0] =  0;
-        mat[1] =  1;
-        mat[4] = -1;
-        mat[5] =  0;
-    }
-    else if(2 == rotate) // 180 degree
-    {
-        mat[0] = -1;
-        mat[1] =  0;
-        mat[4] =  0;
-        mat[5] =  -1;
-    }
-    else if(3 == rotate) // 270 degree
-    {
-        mat[0] =  0;
-        mat[1] = -1;
-        mat[4] =  1;
-        mat[5] =  0;
-    }
-    else /* 0 degree, also fallback if input is wrong) */
-    {
-        mat[0] =  1;
-        mat[1] =  0;
-        mat[4] =  0;
-        mat[5] =  1;
-    }
-
-    glUniformMatrix4fv(loc, 1, GL_FALSE, mat);
-}
 
 COGL_FragmentProgramCombiner::COGL_FragmentProgramCombiner(CRender *pRender)
 : COGLColorCombiner4(pRender)
@@ -626,12 +561,6 @@ int COGL_FragmentProgramCombiner::ParseDecodedMux()
         OPENGL_CHECK_ERRORS;
         res.FogMinMaxLocation = glGetUniformLocation(res.programID,"FogMinMax");
         OPENGL_CHECK_ERRORS;
-
-        GLint rotation_matrix_location = glGetUniformLocation(res.programID, "rotation_matrix");
-        if(-1 != rotation_matrix_location)
-        {
-            set_rotation_matrix(rotation_matrix_location, options.rotate);
-        }
 
         res.dwMux0 = m_pDecodedMux->m_dwMux0;
         res.dwMux1 = m_pDecodedMux->m_dwMux1;


### PR DESCRIPTION
This reverts commit e9ef968bd5961181099072b710e1c200f88106f6.

The previous commit introduced numerous regressions described here: #17, #24, #25.