### PR TITLE
Fix build error in Android.

### DIFF
--- a/src/liblinux/BMGUtils.c
+++ b/src/liblinux/BMGUtils.c
@@ -28,8 +28,8 @@
 #include <stdlib.h>
 
 #include "BMGUtils.h"
-#include "osal_preproc.h"
-#include "liblinux/BMGImage.h"
+#include "../osal_preproc.h"
+#include "BMGImage.h"
 
 #ifndef _WIN32
 #include <string.h>


### PR DESCRIPTION
This fixes the paths to match those used in the header, BMGUtils.h.  Not sure how this was even building on the other platforms.