### PR TITLE
Fix building with USE_GLES=1

### DIFF
--- a/src/osal_opengl.h
+++ b/src/osal_opengl.h
@@ -31,6 +31,8 @@
 #define VS_TEXCOORD1            3
 #define VS_FOG                  4
 
+#define GL_DEPTH_CLAMP_NV       0x864F
+
 #ifndef USE_GLES
 
 #ifndef SDL_VIDEO_OPENGL


### PR DESCRIPTION
This will fix building mupen64plus-video-rice with `make USE_GLES=1 all` on Slackware64-current.
```
    CXX _obj/OGLTexture.o
../../src/OGLRender.cpp: In member function ‘virtual void OGLRender::Initialize()’:
../../src/OGLRender.cpp:111:18: error: ‘GL_DEPTH_CLAMP_NV’ was not declared in this scope
         glEnable(GL_DEPTH_CLAMP_NV);
                  ^
    CXX _obj/Render.o
Makefile:419: recipe for target '_obj/OGLRender.o' failed
make: *** [_obj/OGLRender.o] Error 1
make: *** Waiting for unfinished jobs....
make: *** wait: No child processes.  Stop.
```