### PR TITLE
Update homepage links

### DIFF
--- a/README
+++ b/README
@@ -5,7 +5,7 @@ Mupen64plus-video-rice README                                              v2.5
 ===============================================================================
 
 The latest version of this document can be found online at:
-https://code.google.com/p/mupen64plus/wiki/HighResolutionTextures
+https://mupen64plus.org/wiki/index.php/HighResolutionTextures
 
 -------------------------------------------------------------------------------
 ABOUT

--- a/projects/unix/Makefile
+++ b/projects/unix/Makefile
@@ -67,7 +67,7 @@ ifeq ("$(patsubst MINGW%,MINGW,$(UNAME))","MINGW")
   PIC = 0
 endif
 ifeq ("$(OS)","NONE")
-  $(error OS type "$(UNAME)" not supported.  Please file bug report at 'http://code.google.com/p/mupen64plus/issues')
+  $(error OS type "$(UNAME)" not supported.  Please file bug report at 'https://github.com/mupen64plus/mupen64plus-core/issues')
 endif
 
 # detect system architecture
@@ -114,7 +114,7 @@ ifneq ("$(filter arm%,$(HOST_CPU))","")
   endif
 endif
 ifeq ("$(CPU)","NONE")
-  $(error CPU type "$(HOST_CPU)" not supported.  Please file bug report at 'http://code.google.com/p/mupen64plus/issues')
+  $(error CPU type "$(HOST_CPU)" not supported.  Please file bug report at 'https://github.com/mupen64plus/mupen64plus-core/issues')
 endif
 
 # base CFLAGS, LDLIBS, and LDFLAGS

--- a/projects/unix/Makefile
+++ b/projects/unix/Makefile
@@ -1,6 +1,6 @@
 #/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
 # *   Mupen64plus-video-rice - Makefile                                     *
-# *   Mupen64Plus homepage: http://code.google.com/p/mupen64plus/           *
+# *   Mupen64Plus homepage: https://mupen64plus.org/                        *
 # *   Copyright (C) 2007-2009 Richard Goedeken                              *
 # *   Copyright (C) 2007-2008 DarkJeztr Tillin9                             *
 # *                                                                         *

--- a/src/COLOR.h
+++ b/src/COLOR.h
@@ -1,6 +1,6 @@
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
  *   Mupen64plus - COLOR.h                                                 *
- *   Mupen64Plus homepage: http://code.google.com/p/mupen64plus/           *
+ *   Mupen64Plus homepage: https://mupen64plus.org/                        *
  *   Copyright (C) 2002 Rice1964                                           *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *

--- a/src/OGLCombiner.cpp
+++ b/src/OGLCombiner.cpp
@@ -1,6 +1,6 @@
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
  *   Mupen64plus - OGLCombiner.cpp                                         *
- *   Mupen64Plus homepage: http://code.google.com/p/mupen64plus/           *
+ *   Mupen64Plus homepage: https://mupen64plus.org/                        *
  *   Copyright (C) 2003 Rice1964                                           *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *

--- a/src/OGLCombiner.h
+++ b/src/OGLCombiner.h
@@ -1,6 +1,6 @@
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
  *   Mupen64plus - OGLCombiner.h                                           *
- *   Mupen64Plus homepage: http://code.google.com/p/mupen64plus/           *
+ *   Mupen64Plus homepage: https://mupen64plus.org/                        *
  *   Copyright (C) 2002 Rice1964                                           *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *

--- a/src/TextureFilters_hq2x.cpp
+++ b/src/TextureFilters_hq2x.cpp
@@ -1,6 +1,6 @@
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
  *   Mupen64plus - TextureFilters_hq2x.cpp                                 *
- *   Mupen64Plus homepage: http://code.google.com/p/mupen64plus/           *
+ *   Mupen64Plus homepage: https://mupen64plus.org/                        *
  *   Copyright (C) 2003 MaxSt ( maxst@hiend3d.com )                        *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *

--- a/src/TextureFilters_hq2x.h
+++ b/src/TextureFilters_hq2x.h
@@ -1,6 +1,6 @@
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
  *   Mupen64plus - TextureFilters_hq2x.h                                   *
- *   Mupen64Plus homepage: http://code.google.com/p/mupen64plus/           *
+ *   Mupen64Plus homepage: https://mupen64plus.org/                        *
  *   Copyright (C) 2003 Rice1964                                           *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *

--- a/src/TextureFilters_hq4x.cpp
+++ b/src/TextureFilters_hq4x.cpp
@@ -1,6 +1,6 @@
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
  *   Mupen64plus - TextureFilters_hq4x.cpp                                 *
- *   Mupen64Plus homepage: http://code.google.com/p/mupen64plus/           *
+ *   Mupen64Plus homepage: https://mupen64plus.org/                        *
  *   Copyright (C)  2003 MaxSt ( maxst@hiend3d.com )                       *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *

--- a/src/TextureFilters_hq4x.h
+++ b/src/TextureFilters_hq4x.h
@@ -1,6 +1,6 @@
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
  *   Mupen64plus - TextureFilters_hq4x.h                                   *
- *   Mupen64Plus homepage: http://code.google.com/p/mupen64plus/           *
+ *   Mupen64Plus homepage: https://mupen64plus.org/                        *
  *   Copyright (C) 2003 MaxSt ( maxst@hiend3d.com )                        *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *

--- a/src/TextureFilters_lq2x.h
+++ b/src/TextureFilters_lq2x.h
@@ -1,6 +1,6 @@
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
  *   Mupen64plus - TextureFilters_lq2x.h                                   *
- *   Mupen64Plus homepage: http://code.google.com/p/mupen64plus/           *
+ *   Mupen64Plus homepage: https://mupen64plus.org/                        *
  *   Copyright (C) 2003 MaxSt ( maxst@hiend3d.com )                        *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *

--- a/src/VectorMath.cpp
+++ b/src/VectorMath.cpp
@@ -1,6 +1,6 @@
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
  *   Mupen64plus - VectorMath.cpp                                          *
- *   Mupen64Plus homepage: http://code.google.com/p/mupen64plus/           *
+ *   Mupen64Plus homepage: https://mupen64plus.org/                        *
  *   Copyright (C) 2002 Rice1964                                           *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *

--- a/src/VectorMath.h
+++ b/src/VectorMath.h
@@ -1,6 +1,6 @@
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
  *   Mupen64plus - VectorMath.h                                            *
- *   Mupen64Plus homepage: http://code.google.com/p/mupen64plus/           *
+ *   Mupen64Plus homepage: https://mupen64plus.org/                        *
  *   Copyright (C) 2002 Rice1964                                           *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *

--- a/src/osal_dynamiclib.h
+++ b/src/osal_dynamiclib.h
@@ -1,6 +1,6 @@
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
  *   Mupen64plus-core - osal/dynamiclib.h                                  *
- *   Mupen64Plus homepage: http://code.google.com/p/mupen64plus/           *
+ *   Mupen64Plus homepage: https://mupen64plus.org/                        *
  *   Copyright (C) 2009 Richard Goedeken                                   *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *

--- a/src/osal_dynamiclib_unix.c
+++ b/src/osal_dynamiclib_unix.c
@@ -1,6 +1,6 @@
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
  *   Mupen64plus-core - osal/dynamiclib_unix.c                             *
- *   Mupen64Plus homepage: http://code.google.com/p/mupen64plus/           *
+ *   Mupen64Plus homepage: https://mupen64plus.org/                        *
  *   Copyright (C) 2009 Richard Goedeken                                   *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *

--- a/src/osal_dynamiclib_win32.c
+++ b/src/osal_dynamiclib_win32.c
@@ -1,6 +1,6 @@
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
  *   Mupen64plus-ui-console - osal_dynamiclib_win32.c                      *
- *   Mupen64Plus homepage: http://code.google.com/p/mupen64plus/           *
+ *   Mupen64Plus homepage: https://mupen64plus.org/                        *
  *   Copyright (C) 2009 Richard Goedeken                                   *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *

--- a/src/osal_files.h
+++ b/src/osal_files.h
@@ -1,6 +1,6 @@
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
  *   Mupen64plus-ui-console - osal_files.h                                 *
- *   Mupen64Plus homepage: http://code.google.com/p/mupen64plus/           *
+ *   Mupen64Plus homepage: https://mupen64plus.org/                        *
  *   Copyright (C) 2009 Richard Goedeken                                   *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *

--- a/src/osal_files_unix.c
+++ b/src/osal_files_unix.c
@@ -1,6 +1,6 @@
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
  *   Mupen64plus-core - osal_files_unix.c                                  *
- *   Mupen64Plus homepage: http://code.google.com/p/mupen64plus/           *
+ *   Mupen64Plus homepage: https://mupen64plus.org/                        *
  *   Copyright (C) 2009 Richard Goedeken                                   *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *

--- a/src/osal_files_win32.c
+++ b/src/osal_files_win32.c
@@ -1,6 +1,6 @@
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
  *   Mupen64plus-core - osal_files_win32.c                                 *
- *   Mupen64Plus homepage: http://code.google.com/p/mupen64plus/           *
+ *   Mupen64Plus homepage: https://mupen64plus.org/                        *
  *   Copyright (C) 2009 Richard Goedeken                                   *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *

--- a/src/osal_opengl.h
+++ b/src/osal_opengl.h
@@ -1,6 +1,6 @@
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
  *   Mupen64plus - osal_opengl.h                                           *
- *   Mupen64Plus homepage: http://code.google.com/p/mupen64plus/           *
+ *   Mupen64Plus homepage: https://mupen64plus.org/                        *
  *   Copyright (C) 2013 Richard Goedeken                                   *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *

--- a/src/osal_preproc.h
+++ b/src/osal_preproc.h
@@ -1,6 +1,6 @@
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
  *   Mupen64plus - osal_preproc.h                                          *
- *   Mupen64Plus homepage: http://code.google.com/p/mupen64plus/           *
+ *   Mupen64Plus homepage: https://mupen64plus.org/                        *
  *   Copyright (C) 2009 Richard Goedeken                                   *
  *   Copyright (C) 2002 Hacktarux                                          *
  *                                                                         *

--- a/src/version.h
+++ b/src/version.h
@@ -1,6 +1,6 @@
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
  *   Mupen64plus-video-rice - version.h                                    *
- *   Mupen64Plus homepage: http://code.google.com/p/mupen64plus/           *
+ *   Mupen64Plus homepage: https://mupen64plus.org/                        *
  *   Copyright (C) 2009-2011 Richard Goedeken                              *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *


### PR DESCRIPTION
Linking to the Google Code page isn’t much use anymore.

Across all repos, I changed issue tracker links to the Github tracker, wiki links to the mupen64plus.org wiki, and homepage links to mupen64plus.org.

For the most part I didn’t link to individual repos, for maintenance reasons (if we ever move away from Github, or if we copy files across repos, or…).