### PR TITLE
Add build support for aarch64

### DIFF
--- a/projects/unix/Makefile
+++ b/projects/unix/Makefile
@@ -121,6 +121,12 @@ ifneq ("$(filter arm%,$(HOST_CPU))","")
     $(warning Architecture "$(HOST_CPU)" not officially supported.')
   endif
 endif
+ifneq ("$(filter aarch64,$(HOST_CPU))","")
+    CPU := AARCH
+    ARCH_DETECTED := 64BITS
+    PIC ?= 1
+    NO_ASM := 1
+endif
 ifeq ("$(CPU)","NONE")
   $(error CPU type "$(HOST_CPU)" not supported.  Please file bug report at 'https://github.com/mupen64plus/mupen64plus-core/issues')
 endif


### PR DESCRIPTION
This is supposed to fix https://github.com/mupen64plus/mupen64plus-video-rice/issues/85