### PR TITLE
CI/CD: Integrate scheduled builds and other...

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,10 @@ on:
       - '**/*.md'
       - '.{gitattributes,gitignore,travis.yml}'
       - 'appveyor.yml,README'
+  schedule:
+    - cron: '20 14 21 * *'
   workflow_dispatch:
+
 jobs:
 
   Linux:
@@ -33,14 +36,16 @@ jobs:
             bits: 32
     name: Linux / ${{ matrix.cc }} / ${{ matrix.platform }}
     runs-on: ubuntu-22.04
+    if: (github.event_name == 'schedule' && github.repository == 'mupen64plus/mupen64plus-video-rice') || (github.event_name != 'schedule')
     steps:
       - uses: actions/checkout@v3
       - name: Get build dependencies and arrange the environment
         run: |
-          if [[ "${{ matrix.platform }}" == "x86" ]]; then sudo dpkg --add-architecture i386; fi
+          echo "G_REV=$(git rev-parse --short HEAD)" >> "${GITHUB_ENV}"
+          if [[ ${{ matrix.bits }} -eq 32 ]]; then sudo dpkg --add-architecture i386; fi
           sudo apt-get update
           sudo apt-get -y install libgl1-mesa-dev libpng-dev libsdl1.2-dev libsdl2-dev zlib1g-dev
-          if [[ "${{ matrix.platform }}" == "x86" ]]; then
+          if [[ ${{ matrix.bits }} -eq 32 ]]; then
             sudo apt-get --reinstall -y install gcc-multilib g++-multilib libc6 libc6-dev-i386 libgl1-mesa-glx:i386 libpng16-16:i386 libsdl1.2debian:i386 libsdl2-2.0-0:i386 zlib1g:i386
             LINK="sudo ln -s -T"
             cd /usr/lib/i386-linux-gnu
@@ -53,27 +58,23 @@ jobs:
             if ! [[ -f _real_SDL_config.h ]]; then ${LINK} ../x86_64-linux-gnu/SDL2/_real_SDL_config.h _real_SDL_config.h; fi
           fi
           sudo ldconfig
-      - name: Build and related stuff
+      - name: Build and related stuff, backup binaries
         run: |
-          if [[ ${{ matrix.bits }} -eq 32 ]]; then export OPTFLAGS="-O2 -flto -mtune=pentium4"; else export OPTFLAGS="-O2 -flto -mtune=core2"; fi
-          G_REV=$(git rev-parse --short HEAD)
-          echo "G_REV=${G_REV}" >> "${GITHUB_ENV}"
+          if [[ ${{ matrix.bits }} -eq 32 ]]; then export PIC="1" CPU_TUNE="-msse2 -mtune=pentium4"; else CPU_TUNE="-mtune=core2"; fi
+          export OPTFLAGS="-O2 -flto ${CPU_TUNE}"
           ORIG="$(pwd)"
-          if [[ "${{ matrix.cc }}" == "GCC" ]]; then
-            CC="gcc"
-            CXX="g++"
-          else
+          CC="gcc"
+          CXX="g++"
+          if [[ "${{ matrix.cc }}" != "GCC" ]]; then
             CC="clang"
             CXX="clang++"
           fi
-          if [[ ${{ matrix.bits }} -eq 32 ]]; then export PIC="1"; fi
           ${CC} --version
           echo ""
           git clone --depth 1 https://github.com/mupen64plus/mupen64plus-core.git ../mupen64plus-core
           MSG="1.2"
-          mkdir tmp
-          for SDL in sdl sdl2
-          do
+          mkdir pkg
+          for SDL in sdl sdl2; do
             echo ""
             echo ":: ${{ matrix.cc }} ${{ matrix.platform }} / SDL${MSG} ::"
             echo ""
@@ -81,22 +82,20 @@ jobs:
             echo ""
             make CC="${CC}" CXX="${CXX}" BITS="${{ matrix.bits }}" SDL_CONFIG="${SDL}-config" -C projects/unix all -j4
             echo ""
-            make -C projects/unix install DESTDIR="${ORIG}/tmp"
+            make -C projects/unix install DESTDIR="${ORIG}/pkg/"
             echo ""
-            cd tmp/usr/local/lib/mupen64plus
-            ls -gG *.so
-            ldd mupen64plus-video-rice.so
+            ls -gG pkg/usr/local/lib/mupen64plus/*.so
+            echo ""
+            ldd pkg/usr/local/lib/mupen64plus/mupen64plus-video-rice.so
             MSG="2"
-            cd "${ORIG}"
           done
-          mkdir pkg
-          if [[ "${CC}" == "gcc" ]]; then tar cvzf pkg/mupen64plus-video-rice-${{ matrix.platform }}-g${G_REV}.tar.gz -C tmp/ "usr"; fi
+          tar cvzf pkg/mupen64plus-video-rice-linux-${{ matrix.platform }}-g${{ env.G_REV }}.tar.gz -C pkg/ "usr"
       - name: Upload artifact
+        if: matrix.cc == 'GCC'
         uses: actions/upload-artifact@v3
         with:
-          name: mupen64plus-video-rice-${{ matrix.platform }}-g${{ env.G_REV }}
-          path: pkg/*
-          if-no-files-found: ignore
+          name: mupen64plus-video-rice-linux-${{ matrix.platform }}-g${{ env.G_REV }}
+          path: pkg/*.tar.gz
 
   MSYS2:
     strategy:
@@ -112,7 +111,8 @@ jobs:
             cross: i686
             bits: 32
     name: Windows / MSYS2 ${{ matrix.cc }} / ${{ matrix.platform }}
-    runs-on: windows-2019
+    runs-on: windows-2022
+    if: (github.event_name == 'schedule' && github.repository == 'mupen64plus/mupen64plus-video-rice') || (github.event_name != 'schedule')
     defaults:
       run:
         shell: msys2 {0}
@@ -131,17 +131,18 @@ jobs:
             mingw-w64-${{ matrix.cross }}-libpng
             mingw-w64-${{ matrix.cross }}-SDL2
             mingw-w64-${{ matrix.cross }}-zlib
-      - name: Build and related stuff
+      - name: Build and related stuff, backup binaries
         run: |
-          if [[ ${{ matrix.bits }} -eq 32 ]]; then export OPTFLAGS="-O2 -flto -mtune=pentium4"; else export OPTFLAGS="-O2 -flto -mtune=core2"; fi
           echo "G_REV=$(git rev-parse --short HEAD)" >> "${GITHUB_ENV}"
+          if [[ ${{ matrix.bits }} -eq 32 ]]; then CPU_TUNE="-msse2 -mtune=pentium4"; else CPU_TUNE="-mtune=core2"; fi
+          export OPTFLAGS="-O2 -flto ${CPU_TUNE}"
           ORIG="$(pwd)"
           CC="gcc"
           CXX="g++"
           ${CC} --version
           echo ""
           git clone --depth 1 https://github.com/mupen64plus/mupen64plus-core.git ../mupen64plus-core
-          mkdir tmp
+          mkdir pkg
           echo ""
           echo ":: ${{ matrix.cc }} ${{ matrix.platform }} / SDL2 ::"
           echo ""
@@ -149,32 +150,17 @@ jobs:
           echo ""
           make CC="${CC}" CXX="${CXX}" BITS="${{ matrix.bits }}" -C projects/unix all -j4
           echo ""
-          make -C projects/unix install PLUGINDIR="" SHAREDIR="" BINDIR="" MANDIR="" LIBDIR="" APPSDIR="" ICONSDIR="icons" INCDIR="api" LDCONFIG="true" DESTDIR="${ORIG}/tmp"
+          make -C projects/unix install PLUGINDIR="" SHAREDIR="" BINDIR="" MANDIR="" LIBDIR="" APPSDIR="" ICONSDIR="icons" INCDIR="api" LDCONFIG="true" DESTDIR="${ORIG}/pkg/"
           echo ""
-          ls -gG tmp/*.dll
-          ldd tmp/mupen64plus-video-rice.dll
-      - name: Copy binaries, dependencies, etc...
+          ls -gG pkg/*.dll
+          echo ""
+          ldd pkg/mupen64plus-video-rice.dll
+      - name: Backup dependencies, etc...
         run: |
-          mkdir pkg
           if [[ ${{ matrix.bits }} -eq 32 ]]; then LIBGCC="libgcc_s_dw2-1"; else LIBGCC="libgcc_s_seh-1"; fi
-          for LIB in ${LIBGCC} libpng16-16 libstdc++-6 libwinpthread-1 SDL2 zlib1
-          do
+          for LIB in ${LIBGCC} libpng16-16 libstdc++-6 libwinpthread-1 SDL2 zlib1; do
             echo ":: Copying ${LIB}.dll"
             cp "/mingw${{ matrix.bits }}/bin/${LIB}.dll" pkg/
-          done
-          if [ -d data ]; then
-            cd data
-            for DAT in *
-            do
-              echo ":: Copying ${DAT}"
-              cp -r "${DAT}" ../pkg/
-            done
-          fi
-          cd ../tmp
-          for BIN in *.dll
-          do
-            echo ":: Copying ${BIN}"
-            cp "${BIN}" ../pkg/
           done
       - name: Upload artifact
         uses: actions/upload-artifact@v3
@@ -193,20 +179,18 @@ jobs:
           - toolset: v141_xp
             platform: x86
             vs: 2019
-    name: Windows / MSVC ${{ matrix.toolset }} / ${{ matrix.platform }}
+    name: Windows / MSVC with ${{ matrix.toolset }} / ${{ matrix.platform }}
     runs-on: windows-${{ matrix.vs }}
+    if: (github.event_name == 'schedule' && github.repository == 'mupen64plus/mupen64plus-video-rice') || (github.event_name != 'schedule')
     defaults:
       run:
         shell: cmd
     steps:
       - uses: actions/checkout@v3
       - uses: microsoft/setup-msbuild@v1
-    #  with:
-    #    vs-version: 16.11
-      - name: Build and related stuff
+      - name: Build and related stuff, backup binaries
         run: |
-          for /f "tokens=1" %%R in ('git rev-parse --short HEAD') do set "G_REV=%%R"
-          echo G_REV=%G_REV%>> "%GITHUB_ENV%"
+          for /f "tokens=1" %%R in ('git rev-parse --short HEAD') do echo G_REV=%%R>> "%GITHUB_ENV%"
           set "ARCH=${{ matrix.platform }}"
           if [%ARCH%] == [x86] set "ARCH=Win32"
           echo.
@@ -214,20 +198,17 @@ jobs:
           echo.
           git clone --depth 1 https://github.com/mupen64plus/mupen64plus-core.git ..\mupen64plus-core
           git clone --depth 1 https://github.com/mupen64plus/mupen64plus-win32-deps.git ..\mupen64plus-win32-deps
+          md pkg
           echo.
           msbuild projects\msvc\mupen64plus-video-rice.vcxproj /p:Configuration=Release;Platform=%ARCH%;PlatformToolset=${{ matrix.toolset }}
           echo.
-          md backup
-          copy projects\msvc\%ARCH%\Release\mupen64plus-video-rice.dll backup\
-          dir backup\*.dll
-      - name: Copy binaries, dependencies, etc...
+          copy "projects\msvc\%ARCH%\Release\mupen64plus-video-rice.dll" pkg\
+          dir pkg\*.dll
+      - name: Backup dependencies, etc...
         run: |
-          md pkg
-          cd pkg
-          xcopy "..\backup" .
-          xcopy "..\data" .
-          copy "..\..\mupen64plus-win32-deps\libpng-1.6.38\lib\${{ matrix.platform }}\*.dll" .
-          copy "..\..\mupen64plus-win32-deps\SDL2-2.24.0\lib\${{ matrix.platform }}\*.dll" .
+          xcopy data pkg
+          copy "..\mupen64plus-win32-deps\libpng-1.6.39\lib\${{ matrix.platform }}\*.dll" pkg\
+          copy "..\mupen64plus-win32-deps\SDL2-2.26.3\lib\${{ matrix.platform }}\*.dll" pkg\
       - name: Upload artifact
         uses: actions/upload-artifact@v3
         with:
@@ -236,8 +217,8 @@ jobs:
 
   Nightly-build:
     runs-on: ubuntu-latest
+    if: github.ref_name == 'master'
     needs: [Linux, MSYS2, MSVC]
-    if: github.ref == 'refs/heads/master'
     steps:
       - uses: actions/checkout@v3
       - name: Download artifacts
@@ -252,8 +233,7 @@ jobs:
         run: |
           mkdir pkg
           cd binaries
-          for BIN in *
-          do
+          for BIN in *; do
             cd "${BIN}"
             if [[ "${BIN:23:4}" == "msys" ]]; then
               echo ":: Creating ${BIN}.zip"
@@ -269,10 +249,9 @@ jobs:
           done
           cd ../pkg
           echo ""
-          for BIN in *
-          do
+          for BIN in *; do
             ls -gG ${BIN}
-            tigerdeep -l ${BIN} >> ../${BIN:0:22}.tiger.txt
+            tigerdeep -lz ${BIN} >> ../${BIN:0:22}.tiger.txt
             sha256sum ${BIN} >> ../${BIN:0:22}.sha256.txt
             sha512sum ${BIN} >> ../${BIN:0:22}.sha512.txt
           done

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,6 +2,8 @@ version: 1.0.{build}
 
 image: Visual Studio 2022
 
+skip_tags: true
+
 skip_commits:
   files:
     - '**/*.md'
@@ -11,10 +13,6 @@ skip_commits:
     - .gitignore
     - .travis.yml
     - README
-
-branches:
-  except:
-    - nightly-build
 
 configuration:
   - Release

--- a/projects/msvc/mupen64plus-video-rice.vcxproj
+++ b/projects/msvc/mupen64plus-video-rice.vcxproj
@@ -76,14 +76,14 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>
       <Optimization>Disabled</Optimization>
-      <AdditionalIncludeDirectories>..\..\src;..\..\..\mupen64plus-core\src\api;..\..\..\mupen64plus-win32-deps\SDL2-2.24.0\include;..\..\..\mupen64plus-win32-deps\libpng-1.6.38\include;..\..\..\mupen64plus-win32-deps\zlib-1.2.12\include;..\..\..\mupen64plus-win32-deps\opengl\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\..\src;..\..\..\mupen64plus-core\src\api;..\..\..\mupen64plus-win32-deps\SDL2-2.26.3\include;..\..\..\mupen64plus-win32-deps\libpng-1.6.39\include;..\..\..\mupen64plus-win32-deps\zlib-1.2.13\include;..\..\..\mupen64plus-win32-deps\opengl\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>WIN32;_WINDOWS;_USRDLL;_CRT_SECURE_NO_DEPRECATE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
       <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
       <WarningLevel>Level3</WarningLevel>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>user32.lib;gdi32.lib;opengl32.lib;glu32.lib;..\..\..\mupen64plus-win32-deps\SDL2-2.24.0\lib\x86\SDL2.lib;..\..\..\mupen64plus-win32-deps\libpng-1.6.38\lib\x86\libpng16.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>user32.lib;gdi32.lib;opengl32.lib;glu32.lib;..\..\..\mupen64plus-win32-deps\SDL2-2.26.3\lib\x86\SDL2.lib;..\..\..\mupen64plus-win32-deps\libpng-1.6.39\lib\x86\libpng16.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <SubSystem>Windows</SubSystem>
     </Link>
@@ -91,21 +91,21 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <ClCompile>
       <Optimization>Disabled</Optimization>
-      <AdditionalIncludeDirectories>..\..\src;..\..\..\mupen64plus-core\src\api;..\..\..\mupen64plus-win32-deps\SDL2-2.24.0\include;..\..\..\mupen64plus-win32-deps\libpng-1.6.38\include;..\..\..\mupen64plus-win32-deps\zlib-1.2.12\include;..\..\..\mupen64plus-win32-deps\opengl\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\..\src;..\..\..\mupen64plus-core\src\api;..\..\..\mupen64plus-win32-deps\SDL2-2.26.3\include;..\..\..\mupen64plus-win32-deps\libpng-1.6.39\include;..\..\..\mupen64plus-win32-deps\zlib-1.2.13\include;..\..\..\mupen64plus-win32-deps\opengl\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>WIN32;_WINDOWS;_USRDLL;_CRT_SECURE_NO_DEPRECATE;NO_ASM;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
       <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
       <WarningLevel>Level3</WarningLevel>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>user32.lib;gdi32.lib;opengl32.lib;glu32.lib;..\..\..\mupen64plus-win32-deps\SDL2-2.24.0\lib\x64\SDL2.lib;..\..\..\mupen64plus-win32-deps\libpng-1.6.38\lib\x64\libpng16.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>user32.lib;gdi32.lib;opengl32.lib;glu32.lib;..\..\..\mupen64plus-win32-deps\SDL2-2.26.3\lib\x64\SDL2.lib;..\..\..\mupen64plus-win32-deps\libpng-1.6.39\lib\x64\libpng16.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <SubSystem>Windows</SubSystem>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <ClCompile>
-      <AdditionalIncludeDirectories>..\..\src;..\..\..\mupen64plus-core\src\api;..\..\..\mupen64plus-win32-deps\SDL2-2.24.0\include;..\..\..\mupen64plus-win32-deps\libpng-1.6.38\include;..\..\..\mupen64plus-win32-deps\zlib-1.2.12\include;..\..\..\mupen64plus-win32-deps\opengl\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\..\src;..\..\..\mupen64plus-core\src\api;..\..\..\mupen64plus-win32-deps\SDL2-2.26.3\include;..\..\..\mupen64plus-win32-deps\libpng-1.6.39\include;..\..\..\mupen64plus-win32-deps\zlib-1.2.13\include;..\..\..\mupen64plus-win32-deps\opengl\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>WIN32;NDEBUG;_WINDOWS;_USRDLL;_CRT_SECURE_NO_DEPRECATE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
       <WarningLevel>Level3</WarningLevel>
@@ -114,7 +114,7 @@
       <IntrinsicFunctions>true</IntrinsicFunctions>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>user32.lib;gdi32.lib;opengl32.lib;glu32.lib;..\..\..\mupen64plus-win32-deps\SDL2-2.24.0\lib\x86\SDL2.lib;..\..\..\mupen64plus-win32-deps\libpng-1.6.38\lib\x86\libpng16.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>user32.lib;gdi32.lib;opengl32.lib;glu32.lib;..\..\..\mupen64plus-win32-deps\SDL2-2.26.3\lib\x86\SDL2.lib;..\..\..\mupen64plus-win32-deps\libpng-1.6.39\lib\x86\libpng16.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <SubSystem>Windows</SubSystem>
       <OptimizeReferences>true</OptimizeReferences>
@@ -123,7 +123,7 @@
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <ClCompile>
-      <AdditionalIncludeDirectories>..\..\src;..\..\..\mupen64plus-core\src\api;..\..\..\mupen64plus-win32-deps\SDL2-2.24.0\include;..\..\..\mupen64plus-win32-deps\libpng-1.6.38\include;..\..\..\mupen64plus-win32-deps\zlib-1.2.12\include;..\..\..\mupen64plus-win32-deps\opengl\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\..\src;..\..\..\mupen64plus-core\src\api;..\..\..\mupen64plus-win32-deps\SDL2-2.26.3\include;..\..\..\mupen64plus-win32-deps\libpng-1.6.39\include;..\..\..\mupen64plus-win32-deps\zlib-1.2.13\include;..\..\..\mupen64plus-win32-deps\opengl\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>WIN32;NDEBUG;_WINDOWS;_USRDLL;_CRT_SECURE_NO_DEPRECATE;NO_ASM;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
       <WarningLevel>Level3</WarningLevel>
@@ -132,7 +132,7 @@
       <IntrinsicFunctions>true</IntrinsicFunctions>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>user32.lib;gdi32.lib;opengl32.lib;glu32.lib;..\..\..\mupen64plus-win32-deps\SDL2-2.24.0\lib\x64\SDL2.lib;..\..\..\mupen64plus-win32-deps\libpng-1.6.38\lib\x64\libpng16.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>user32.lib;gdi32.lib;opengl32.lib;glu32.lib;..\..\..\mupen64plus-win32-deps\SDL2-2.26.3\lib\x64\SDL2.lib;..\..\..\mupen64plus-win32-deps\libpng-1.6.39\lib\x64\libpng16.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <SubSystem>Windows</SubSystem>
       <OptimizeReferences>true</OptimizeReferences>


### PR DESCRIPTION
Depends on: mupen64plus/mupen64plus-win32-deps#13

Relevant changes:

- Schedule builds at least once a month (upstream only)
- Update some GitHub Actions values
- Bash code simplification and corrections
- Optimize x86 builds with SSE2 on Linux and MSYS2 (sometimes not effective)
- Tag to Linux binaries
- Add file size to tiger hashfile
- AppVeyor: Avoid duplicated jobs as a result of the `nightly-build` tag update.